### PR TITLE
chore(package): Move czConfig into config.commitizen

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
   "bugs": {
     "url": "https://github.com/videogular/videogular2/issues"
   },
-  "czConfig": {
-    "path": "node_modules/cz-conventional-changelog"
-  },
   "config": {
+    "commitizen": {
+      "path": "node_modules/cz-conventional-changelog"
+    },
     "ghooks": {
       "pre-commit": "npm run test"
     }


### PR DESCRIPTION
Commitizen is deprecating czConfig in favor of npm's config object
https://github.com/commitizen/cz-cli/issues/30