### PR TITLE
refactor(rxjs): Import operators individually from rxjs for tree-shaking

### DIFF
--- a/src/controls/vg-controls.spec.ts
+++ b/src/controls/vg-controls.spec.ts
@@ -3,6 +3,8 @@ import {ElementRef} from "@angular/core";
 import {VgAPI} from "../core/services/vg-api";
 import {Observable} from "rxjs/Observable";
 
+import 'rxjs/add/observable/fromEvent';
+
 describe('Controls Bar', () => {
     let controls:VgControls;
     let ref:ElementRef;

--- a/src/controls/vg-controls.ts
+++ b/src/controls/vg-controls.ts
@@ -2,6 +2,8 @@ import { Component, Input, OnInit, ElementRef, Renderer, HostBinding, AfterViewI
 import {Observable} from "rxjs/Observable";
 import {VgAPI} from "../core/services/vg-api";
 
+import 'rxjs/add/observable/fromEvent';
+
 @Component({
     selector: 'vg-controls',
     template: `<ng-content></ng-content>`,

--- a/src/core/vg-cue-points/vg-cue-points.spec.ts
+++ b/src/core/vg-cue-points/vg-cue-points.spec.ts
@@ -1,6 +1,8 @@
 import {ElementRef} from "@angular/core";
-import {Observable} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
 import {VgCuePoints} from "./vg-cue-points";
+
+import 'rxjs/add/observable/fromEvent';
 
 describe('Cue points', () => {
     let cuePoints:VgCuePoints;

--- a/src/core/vg-cue-points/vg-cue-points.ts
+++ b/src/core/vg-cue-points/vg-cue-points.ts
@@ -1,6 +1,8 @@
 import { Directive, Output, Input, EventEmitter, ElementRef, OnInit } from "@angular/core";
 import {VgEvents} from '../events/vg-events';
-import {Observable} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
+
+import 'rxjs/add/observable/fromEvent';
 
 @Directive({
     selector: '[vgCuePoints]'

--- a/src/core/vg-media/vg-media.ts
+++ b/src/core/vg-media/vg-media.ts
@@ -2,10 +2,14 @@ import { ElementRef, OnInit, Directive, Input, OnDestroy } from "@angular/core";
 import { IPlayable, IMediaSubscriptions } from "./i-playable";
 import { Observable } from "rxjs/Observable";
 import { TimerObservable } from "rxjs/observable/TimerObservable";
-import { Observer, Subscription } from "rxjs";
+import { Subscription } from "rxjs/Subscription";
+import { Observer } from "rxjs/Observer";
 import { VgStates } from '../states/vg-states';
 import { VgAPI } from '../services/vg-api';
 import { VgEvents } from '../events/vg-events';
+
+import 'rxjs/add/observable/fromEvent';
+import 'rxjs/add/observable/combineLatest';
 
 @Directive({
     selector: '[vgMedia]'


### PR DESCRIPTION
### Rationale
Importing directly from the rxjs class modules, e.g. `'rxjs/Observable'`, and then patching imports
for only the used operator modules, e.g. `'rxjs/add/observable/fromEvent'`, avoids using the omnibus `'rxjs/Rx'` module and makes it easier for consumers to tree-shake their bundles correctly with tools like rollup & webpack. More information is avaiable in the [rxjs readme](https://github.com/ReactiveX/rxjs#installation-and-usage) as well as in [rxjs#1888](https://github.com/ReactiveX/rxjs/issues/1888).

### Description
 * Changed the `import` statements that pointed to `'rxjs'` (src/core/vg-media/vg-media.d.ts) and `'rxjs/Rx'` (in src/core/vg-cue-points/vg-cue-points.ts, src/core/vg-cue-points/vg-cue-points.spec.ts) to import directly from `'rxjs/Subscription'`/`'rxjs/Observer'` and `'rxjs/Observable'` (respectively).
 * Added operator patch `import` statements (i.e. `import 'rxjs/add/observable/fromEvent';` and `import 'rxjs/add/observable/combineLatest';`) to every file where `Observable.fromEvent()` and `Observable.combineLatest()` are being called (`Observable.create()` is defined in `'rxjs/Observable'` and does not need patching).