### PR TITLE
fix(controls): make volume control rely on bounding box

### DIFF
--- a/src/controls/vg-volume/vg-volume.spec.ts
+++ b/src/controls/vg-volume/vg-volume.spec.ts
@@ -98,9 +98,14 @@ describe('Volume control', () => {
 
     describe('calculateVolume', ()=>{
         it('Shoud calculate volume based on volumeBar position', ()=>{
-            spyOn(document, 'querySelector').and.returnValue({
-                offsetLeft: 5
-            });
+            // mock volumeBarRef ViewChild
+            vgVol.volumeBarRef = {
+              nativeElement: {
+                getBoundingClientRect() {
+                  return { left: 5 }
+                }
+              }
+            };
             expect(vgVol.calculateVolume(10)).toBe(5);
         });
     });

--- a/src/controls/vg-volume/vg-volume.ts
+++ b/src/controls/vg-volume/vg-volume.ts
@@ -1,11 +1,13 @@
-import { Component, Input, ElementRef, HostListener, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, Input, ElementRef, HostListener, OnInit, ViewEncapsulation, ViewChild } from '@angular/core';
 import { VgAPI } from '../../core/services/vg-api';
 
 @Component({
     selector: 'vg-volume',
     encapsulation: ViewEncapsulation.None,
     template: `
-        <div class="volumeBar"
+        <div 
+            #volumeBar
+            class="volumeBar"
             (mousedown)="onMouseDown($event)">
             <div class="volumeBackground" [ngClass]="{dragging: isDragging}">
                 <div class="volumeValue" [style.width]="(getVolume() * (100-15)) + '%'"></div>
@@ -66,6 +68,7 @@ import { VgAPI } from '../../core/services/vg-api';
 })
 export class VgVolume implements OnInit {
     @Input() vgFor: string;
+    @ViewChild('volumeBar') volumeBarRef: ElementRef;
 
     elem: HTMLElement;
     target: any;
@@ -113,10 +116,10 @@ export class VgVolume implements OnInit {
     }
 
     calculateVolume(mousePosX: number) {
-        const volumeBarOffsetLeft: number = (<HTMLElement>document.querySelector('.volumeBar')).offsetLeft;
+        const volumeBarOffsetLeft: number = this.volumeBarRef.nativeElement.getBoundingClientRect().left;
         return mousePosX - volumeBarOffsetLeft;
     }
-
+    
     setVolume(vol: number) {
         this.target.volume = Math.max(0, Math.min(1, vol / 100));
     }


### PR DESCRIPTION
### Description
Use bounding box of the volume bar to get the correct left position to calculate the volume. Also switched to ViewChild. Fixes #286.

Before:
![before-fix](https://cloud.githubusercontent.com/assets/4655972/23314363/ab354c4c-fa8f-11e6-9653-308594ede5b0.gif)


After:

![fixed-volume](https://cloud.githubusercontent.com/assets/4655972/23314301/638271ea-fa8f-11e6-8225-257477321d82.gif)
