### PR TITLE
fix volume percent calculation on small screen

### DIFF
--- a/src/controls/vg-volume/vg-volume.spec.ts
+++ b/src/controls/vg-volume/vg-volume.spec.ts
@@ -102,7 +102,7 @@ describe('Volume control', () => {
             vgVol.volumeBarRef = {
               nativeElement: {
                 getBoundingClientRect() {
-                  return { left: 5 }
+                  return { left: 5, width: 100 }
                 }
               }
             };

--- a/src/controls/vg-volume/vg-volume.ts
+++ b/src/controls/vg-volume/vg-volume.ts
@@ -12,7 +12,7 @@ import { VgAPI } from '../../core/services/vg-api';
             (mousedown)="onMouseDown($event)">
             <div class="volumeBackground" [ngClass]="{dragging: isDragging}">
                 <div class="volumeValue" [style.width]="(getVolume() * (100-15)) + '%'"></div>
-                <div class="volumeKnob" [style.left]="(getVolume() * (100-15)) + 'px'"></div>
+                <div class="volumeKnob" [style.left]="(getVolume() * (100-15)) + '%'"></div>
             </div>
         </div>
     `,
@@ -121,8 +121,10 @@ export class VgVolume implements OnInit {
     }
 
     calculateVolume(mousePosX: number) {
-        const volumeBarOffsetLeft: number = this.volumeBarRef.nativeElement.getBoundingClientRect().left;
-        return mousePosX - volumeBarOffsetLeft;
+        const recObj = this.volumeBarRef.nativeElement.getBoundingClientRect();
+        const volumeBarOffsetLeft: number = recObj.left;
+        const volumeBarWidth: number = recObj.width;
+        return (mousePosX - volumeBarOffsetLeft) / volumeBarWidth * 100;
     }
 
     setVolume(vol: number) {


### PR DESCRIPTION
On iphone 5 (320px) screen, width of vg-volume component is 67px. Older calculation assumes its 100px and doesn't work correctly. (mousePosX - volumeBarOffsetLeft) / volumeBarWidth * 100 on calculateVolume function fixes the problem.