### PR TITLE
feat(vgMedia): Now we can create our custom media elements

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,7 +107,7 @@ Create your video player with HTML in your template:
         <vg-fullscreen></vg-fullscreen>
     </vg-controls>
 
-    <video vgMedia #media id="singleVideo" preload="auto" crossorigin>
+    <video [vgMedia]="media" #media id="singleVideo" preload="auto" crossorigin>
         <source *ngFor="let video of sources" [src]="video.src" [type]="video.type">
         <track kind="subtitles" label="English" src="http://static.videogular.com/assets/subs/pale-blue-dot.vtt" srclang="en" default>
         <track kind="subtitles" label="Español" src="http://static.videogular.com/assets/subs/pale-blue-dot-es.vtt" srclang="es">

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -16,7 +16,7 @@ For example, this is the most basic video player that you can create with Videog
 
 ```html
 <vg-player>
-    <video vgMedia id="singleVideo" preload="auto" controls>
+    <video [vgMedia]="media" #media id="singleVideo" preload="auto" controls>
         <source src="http://static.videogular.com/assets/videos/videogular.mp4" type="video/mp4">
     </video>
 </vg-player>
@@ -52,7 +52,7 @@ Let's go to add an overlay play and a custom control bar.
         <vg-fullscreen></vg-fullscreen>
     </vg-controls>
 
-    <video vgMedia id="singleVideo" preload="auto">
+    <video [vgMedia]="media" #media id="singleVideo" preload="auto">
         <source src="http://static.videogular.com/assets/videos/videogular.mp4" type="video/mp4">
     </video>
 </vg-player>

--- a/docs/master-media.md
+++ b/docs/master-media.md
@@ -32,11 +32,11 @@ In this example we have two videos and `masterVideo` is the master video because
         <vg-fullscreen></vg-fullscreen>
     </vg-controls>
 
-    <video vgMedia="master" id="masterVideo" preload="auto">
+    <video [vgMedia]="master" #master [vgMaster]="true" id="masterVideo" preload="auto">
         <source src="http://static.videogular.com/assets/videos/videogular.mp4" type="video/mp4">
     </video>
 
-    <video vgMedia id="slaveVideo" preload="auto">
+    <video [vgMedia]="slave" #slave id="slaveVideo" preload="auto">
         <source src="http://static.videogular.com/assets/videos/vr-demo.mp4" type="video/mp4">
     </video>
 </vg-player>
@@ -73,7 +73,7 @@ Now you can add `vgFor="video-id"` to decide which `vgMedia` target when a user 
             <vg-fullscreen vgFor="leftVideo"></vg-fullscreen>
         </vg-controls>
     
-        <video vgMedia id="leftVideo" preload="auto">
+        <video [vgMedia]="left" #left id="leftVideo" preload="auto">
             <source src="http://static.videogular.com/assets/videos/videogular.mp4" type="video/mp4">
         </video>
     </div>
@@ -94,7 +94,7 @@ Now you can add `vgFor="video-id"` to decide which `vgMedia` target when a user 
             <vg-fullscreen vgFor="rightVideo"></vg-fullscreen>
         </vg-controls>
         
-        <video vgMedia id="rightVideo" preload="auto">
+        <video [vgMedia]="right" #right id="rightVideo" preload="auto">
             <source src="http://static.videogular.com/assets/videos/vr-demo.mp4" type="video/mp4">
         </video>
     </div>

--- a/docs/using-the-api.md
+++ b/docs/using-the-api.md
@@ -34,7 +34,7 @@ To start using the API first you need to grab it from the player. To do that lis
         <vg-fullscreen></vg-fullscreen>
     </vg-controls>
 
-    <video vgMedia #media id="singleVideo" preload="auto" crossorigin>
+    <video [vgMedia]="media" #media id="singleVideo" preload="auto" crossorigin>
         <source src="http://static.videogular.com/assets/videos/videogular.mp4" type="video/mp4">
     </video>
 </vg-player>

--- a/docs/vg-cue-points/vg-cue-points.md
+++ b/docs/vg-cue-points/vg-cue-points.md
@@ -19,7 +19,7 @@ VgCuePoints will add `cues` property to the track element with all the `VTTCue` 
 
 ```html
 <vg-player>
-    <video id="vid" preload="auto">
+    <video #media [vgMedia]="media" id="vid" preload="auto">
         <source src="http://static.videogular.com/assets/videos/videogular.mp4" type="video/mp4">
         
         <track src="../data/cue-points.vtt" kind="metadata" label="Cue Points" default

--- a/docs/vg-player/vg-player.md
+++ b/docs/vg-player/vg-player.md
@@ -6,7 +6,7 @@ currentMenu: vg-player/vg-player
 
 Main component responsible of the creation of the API. This should be your root component and all videogular components must be placed inside this component.
 
-To create VgAPI, videogular needs that each `vgMedia` directive haves an `id` to build an internal map with all media objects.
+To create VgAPI, videogular needs that each `vgMedia` directive has an `id` to build an internal map with all media objects.
 
 ## Outputs
 
@@ -18,6 +18,6 @@ To create VgAPI, videogular needs that each `vgMedia` directive haves an `id` to
 
 ```html
 <vg-player (onPlayerReady)="onPlayerReady($event)">
-    <video vgMedia id="my-video" src="http://static.videogular.com/assets/videos/videogular.mp4" type="video/mp4">
+    <video #myMedia [vgMedia]="myMedia" id="my-video" src="http://static.videogular.com/assets/videos/videogular.mp4" type="video/mp4">
 </vg-player>
 ```

--- a/src/controls/vg-controls.ts
+++ b/src/controls/vg-controls.ts
@@ -112,7 +112,10 @@ export class VgControls implements OnInit, AfterViewInit {
         clearTimeout(this.timer);
         this.hideControls = false;
         this.hidden.state(false);
-        this.hideAsync();
+
+        if (this.vgAutohide) {
+            this.hideAsync();
+        }
     }
 
     private hideAsync() {

--- a/src/core/vg-media/vg-media.spec.ts
+++ b/src/core/vg-media/vg-media.spec.ts
@@ -33,7 +33,8 @@ describe('Videogular Media', () => {
         };
 
         api = new VgAPI();
-        media = new VgMedia(ref, api);
+        media = new VgMedia(api);
+        media.vgMedia = elem;
     });
 
     xit('Should load a new media if a change on dom have been happened', () => {
@@ -54,7 +55,7 @@ describe('Videogular Media', () => {
     });
 
     it('Should not be master by default', () => {
-        expect(media.vgMedia).toBeFalsy();
+        expect(media.vgMaster).toBeFalsy();
     });
 
     it('Should have a play method', () => {


### PR DESCRIPTION
Now we can create our custom media elements, so this allows us to play anything that has a begin and an end.

BREAKING CHANGE: Now `vgMedia` expects a view reference as param. Created a new property for `vgMaster`.

Before: `<video vgMedia="master">`

After: `<video #myMedia [vgMedia]="myMedia" [vgMaster]="true">`

