### PR TITLE
feat(vgScrubBar): Enable seek using move events

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -63,6 +63,23 @@ This is great! We can add some Videogular components to have a nice UI for our v
 
 The VgScrubBar inside controls has a `pointer-events: none;` to avoid clicks on it but it's necessary to create some space between components. Of course, if you like, you can remove it and create your own `div` with a `class` and it will do the job too. That's the good thing about using custom elements!
 
+You can also enable slider events in the VgScrubBar using the vgSlider attribute:
+```html
+    <vg-scrub-bar [vgSlider]="true">
+        <vg-scrub-bar-current-time></vg-scrub-bar-current-time>
+        <vg-scrub-bar-buffering-time></vg-scrub-bar-buffering-time>
+    </vg-scrub-bar>
+```
+
+Optionally, a circle can be shown in VgScrubBarCurrentTime using the same vgSlider attribute:
+
+```html
+    <vg-scrub-bar [vgSlider]="true">
+        <vg-scrub-bar-current-time [vgSlider]="true"></vg-scrub-bar-current-time>
+        <vg-scrub-bar-buffering-time></vg-scrub-bar-buffering-time>
+    </vg-scrub-bar>
+```
+
 One of the most important things that you need to understand is that all components are not going to work if you don't add a `vgMedia` directive to the `video` tag. So remember to add at least one `vgMedia` on each player.
 
 Now you can create your TypeScript file and compile/bundle with your favourite setup.

--- a/src/controls/vg-scrub-bar/vg-scrub-bar-current-time/vg-scrub-bar-current-time.ts
+++ b/src/controls/vg-scrub-bar/vg-scrub-bar-current-time/vg-scrub-bar-current-time.ts
@@ -4,7 +4,7 @@ import { VgAPI } from '../../../core/services/vg-api';
 @Component({
     selector: 'vg-scrub-bar-current-time',
     encapsulation: ViewEncapsulation.None,
-    template: `<div class="background" [style.width]="getPercentage()"></div>`,
+    template: `<div class="background" [style.width]="getPercentage()"></div><span class="slider" *ngIf="vgSlider"></span>`,
     styles: [ `
         vg-scrub-bar-current-time {
             display: flex;
@@ -32,10 +32,21 @@ import { VgAPI } from '../../../core/services/vg-api';
             -moz-border-radius: 2px;
             border-radius: 2px;
         }
+        
+        vg-scrub-bar-current-time .slider{
+            background: white;
+            height: 15px;
+            width: 15px;
+            border-radius: 50%;
+            box-shadow: 0px 0px 10px black;
+            margin-top: -5px;
+            margin-left: -10px;
+        }
     ` ]
 })
 export class VgScrubBarCurrentTime implements OnInit {
     @Input() vgFor: string;
+    @Input() vgSlider: boolean = false;
 
     elem: HTMLElement;
     target: any;

--- a/src/controls/vg-scrub-bar/vg-scrub-bar.spec.ts
+++ b/src/controls/vg-scrub-bar/vg-scrub-bar.spec.ts
@@ -2,12 +2,32 @@ import {VgScrubBar} from "./vg-scrub-bar";
 import {VgAPI} from "../../core/services/vg-api";
 import {ElementRef} from "@angular/core";
 import {VgControlsHidden} from './../../core/services/vg-controls-hidden';
+import {VgMedia} from "../../core/vg-media/vg-media";
 
 describe('Scrub bar', () => {
     let scrubBar:VgScrubBar;
     let ref:ElementRef;
     let api:VgAPI;
     let vgControlsHiddenState: VgControlsHidden;
+    let media:VgMedia;
+    let elem = {
+        play: () => {},
+        pause: () => {},
+        load: () => {},
+        duration: 100,
+        currentTime: 0,
+        volume: 1,
+        playbackRate: 1,
+        buffered: {
+            length: 2,
+            end: () => {return 50;}
+        },
+        id: 'testVideo',
+        observe: () => {
+            return <any>{};
+        },
+        dispatchEvent: () => {}
+    };
 
     beforeEach(() => {
         ref = {
@@ -20,6 +40,8 @@ describe('Scrub bar', () => {
         };
 
         api = new VgAPI();
+        media = new VgMedia(api);
+        media.vgMedia = elem;
         vgControlsHiddenState = new VgControlsHidden();
 
 
@@ -48,12 +70,188 @@ describe('Scrub bar', () => {
     describe('onMouseDownScrubBar', () => {
         it('should call API seekTime 10 when offsetX is 20 and scrollWidth is 200', () => {
             spyOn(api, 'seekTime');
+            spyOn(api, 'pause');
+
+            media.onCanPlay({});
+            api.registerMedia(media);
 
             scrubBar.target = api;
 
             scrubBar.onMouseDownScrubBar({ offsetX: 20 });
 
             expect(api.seekTime).toHaveBeenCalledWith(10, true);
+
+            scrubBar.vgSlider = true;
+            scrubBar.isSeeking = true;
+
+            scrubBar.onMouseDownScrubBar({ offsetX: 20 });
+
+            expect(api.seekTime).toHaveBeenCalledTimes(1);
+            expect(api.pause).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('onMouseMoveScrubBar', () => {
+        it('should modify time.current to 10 when offsetX is 20 and scrollWidth is 200 and vgSlider is true and isSeeking is true', () => {
+            spyOn(api, 'seekTime');
+
+            scrubBar.target = api;
+
+            scrubBar.onMouseMoveScrubBar({ offsetX: 20 });
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
+
+            scrubBar.vgSlider = true;
+            scrubBar.isSeeking = true;
+
+            scrubBar.onMouseMoveScrubBar({ offsetX: 20 });
+
+            expect(api.seekTime).toHaveBeenCalledWith(10, true);
+        });
+    });
+
+    describe('onMouseOutScrubBar', () => {
+        it('should modify time.current to 10 when offsetX is 20 and scrollWidth is 200 and vgSlider is true and isSeeking is true', () => {
+            spyOn(api, 'seekTime');
+
+            media.onCanPlay({});
+            api.registerMedia(media);
+
+            scrubBar.target = api;
+
+            scrubBar.onMouseOutScrubBar({ offsetX: 20 });
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
+
+            scrubBar.vgSlider = true;
+            scrubBar.isSeeking = true;
+
+            scrubBar.onMouseOutScrubBar({ offsetX: 20 });
+
+            expect(api.seekTime).toHaveBeenCalledWith(10, true);
+        });
+    });
+
+    describe('onMouseUpScrubBar', () => {
+        it('should modify time.current to 10 when offsetX is 20 and scrollWidth is 200 and vgSlider is true and isSeeking is true', () => {
+            spyOn(api, 'seekTime');
+
+            media.onCanPlay({});
+            api.registerMedia(media);
+
+            scrubBar.target = api;
+
+            scrubBar.onMouseUpScrubBar({ offsetX: 20 });
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
+
+            scrubBar.vgSlider = true;
+            scrubBar.isSeeking = true;
+
+            scrubBar.onMouseUpScrubBar({ offsetX: 20 });
+
+            expect(api.seekTime).toHaveBeenCalledWith(10, true);
+        });
+    });
+
+    describe('onTouchStartScrubBar', () => {
+        it('should call API seekTime 10 when offsetX is 20 and scrollWidth is 200', () => {
+            spyOn(api, 'seekTime');
+            spyOn(api, 'pause');
+
+            media.onCanPlay({});
+            api.registerMedia(media);
+
+            scrubBar.target = api;
+
+            scrubBar.onTouchStartScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledWith(10, true);
+            expect(api.pause).toHaveBeenCalledTimes(0);
+
+            scrubBar.vgSlider = true;
+            scrubBar.isSeeking = true;
+
+            scrubBar.onTouchStartScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledTimes(1);
+            expect(api.pause).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('onTouchMoveScrubBar', () => {
+        it('should modify time.current to 10 when offsetX is 20 and scrollWidth is 200 and vgSlider is true and isSeeking is true', () => {
+            spyOn(api, 'seekTime');
+
+            scrubBar.target = api;
+
+            scrubBar.onTouchMoveScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
+
+            scrubBar.vgSlider = true;
+            scrubBar.isSeeking = true;
+
+            scrubBar.onTouchMoveScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledWith(10, true);
+        });
+    });
+
+    describe('onTouchCancelScrubBar', () => {
+        it('should not seek', () => {
+            spyOn(api, 'seekTime');
+
+            scrubBar.target = api;
+
+            scrubBar.onTouchCancelScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
+
+            scrubBar.vgSlider = true;
+            scrubBar.isSeeking = true;
+
+            scrubBar.onTouchCancelScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe('onTouchEndScrubBar', () => {
+        it('should not seek', () => {
+            spyOn(api, 'seekTime');
+
+            scrubBar.target = api;
+
+            scrubBar.onTouchEndScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
+
+            scrubBar.vgSlider = true;
+            scrubBar.isSeeking = true;
+
+            scrubBar.onTouchEndScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
+        });
+    });
+
+    describe('onTouchLeaveScrubBar', () => {
+        it('should not seek', () => {
+            spyOn(api, 'seekTime');
+
+            scrubBar.target = api;
+
+            scrubBar.onTouchLeaveScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
+
+            scrubBar.vgSlider = true;
+            scrubBar.isSeeking = true;
+
+            scrubBar.onTouchLeaveScrubBar({ touches: [ {pageX: 20 }]});
+
+            expect(api.seekTime).toHaveBeenCalledTimes(0);
         });
     });
 });


### PR DESCRIPTION
Users tend to use move gestures to seek through the video, mostly in mobile devices. This commit
enables mouse and touch events to allow this type of seeks. A new option to show a circle in
VgScrubBarCurrentTime is also available. 

### Description

- Modified `vg-scrub-bar` to allow slide movements to seek through the video. This can be enabled using the `[vgSlider]="true"` attribute.
- Modified `vg-scrub-bar-current-time` to show a circle in the current time position. This can be enabled also using the `[vgSlider]="true"` attribute. Users usually know that they can slide the circle to move through the video.
- Modified documentation including this two new attributes.
- Created new tests for the new functions, but surely can be improved.



