### PR TITLE
fix(IMA ADS): Don't throw 'ReferenceError: google is not defined' 

### DIFF
--- a/src/ima-ads/vg-ima-ads.ts
+++ b/src/ima-ads/vg-ima-ads.ts
@@ -58,6 +58,11 @@ export class VgImaAds {
     }
 
     onPlayerReady() {
+        if (typeof google === "undefined") {
+            this.onMissingGoogleImaLoader();
+            return;
+        }
+
         this.target = this.API.getMediaById(this.vgFor);
 
         this.initializations();
@@ -268,6 +273,11 @@ export class VgImaAds {
         if (!this.fsAPI.nativeFullscreen) {
             this.isFullscreen = fsState;
         }
+    }
+
+    private onMissingGoogleImaLoader() {
+        this.hide();
+        this.API.play();
     }
 }
 


### PR DESCRIPTION
Don't throw 'ReferenceError: google is not defined' if ima3.js is not loaded.

If `imasdk.googleapis.com/js/sdkloader/ima3.js` script is loaded later then videogular a `google is not
defined` exception is thrown.

This doesnt happen often, so we're just if()-ing if google is undefined and then skipping banners. In any case, user doesn't see banners, this time he at least doesn't get the exception.

In reference to  #472.