### PR TITLE
fix(HLS): Adds check that target element really has pause method.

### DIFF
--- a/src/streaming/vg-hls/vg-hls.ts
+++ b/src/streaming/vg-hls/vg-hls.ts
@@ -81,7 +81,7 @@ export class VgHLS implements OnInit, OnChanges, OnDestroy {
             this.hls.attachMedia(video);
         }
         else {
-            if (this.target) {
+            if (this.target && !!this.target.pause) {
                 this.target.pause();
                 this.target.seekTime(0);
                 this.ref.nativeElement.src = this.vgHls;


### PR DESCRIPTION
I cannot reproduce this error, but in our error logging service we get errors saying that element
doesn't have the `.pause()` method. Which it really should have but it somehow doesn't. I don't know how else to fix it, other then to add another check.

Fixes #473