### PR TITLE
fix(Win8.1 + ima ads): 'Object doesn't support this action' on Win8.1 + IE11

### DIFF
--- a/src/ima-ads/vg-ima-ads.ts
+++ b/src/ima-ads/vg-ima-ads.ts
@@ -256,12 +256,22 @@ export class VgImaAds {
     }
 
     show() {
-        window.dispatchEvent(new CustomEvent(VgEvents.VG_START_ADS));
+        try {
+            window.dispatchEvent(new CustomEvent(VgEvents.VG_START_ADS));
+        } catch (e) {
+            console.log(e);
+        }
+
         this.displayState = 'block';
     }
 
     hide() {
-        window.dispatchEvent(new CustomEvent(VgEvents.VG_END_ADS));
+        try {
+            window.dispatchEvent(new CustomEvent(VgEvents.VG_END_ADS));
+        } catch (e) {
+            console.log(e);
+        }
+
         this.displayState = 'none';
     }
 


### PR DESCRIPTION
I need some help here.

Windows 8.1 with IE 11 fails with 'Object doesn't support this action' when google ads are enabled.
Specifically it fails at `window.dispatchEvent(new CustomEvent(VgEvents.VG_START_ADS));`, giving no good explanation why. See attachment:

![ads_error](https://cloud.githubusercontent.com/assets/6648783/25307462/a240beac-27a1-11e7-9177-9edde038afa1.png)

Currently I only added a try / catch statement around this blocks. It's not a good fix, because the `<vg-play-pause></vg-play-pause>` button stays in the "ads play" mode. So one has to click it once to switch it to pause and then click again to start playing the video.

Around 10% of our users have Win8.1 and IE11, so if you have a better solution, I'm eagerly listening.
