### PR TITLE
fix(VgMedia) return new track from addTextTrack

### DIFF
--- a/src/core/vg-media/vg-media.ts
+++ b/src/core/vg-media/vg-media.ts
@@ -427,12 +427,13 @@ export class VgMedia implements OnInit, OnDestroy, IPlayable {
         this.currentTime = second;
     }
 
-    addTextTrack(type:string, label?:string, language?:string, mode?:'disabled' | 'hidden' | 'showing') {
+    addTextTrack(type:string, label?:string, language?:string, mode?:'disabled' | 'hidden' | 'showing'): TextTrack {
         const newTrack:TextTrack = this.vgMedia.addTextTrack(type, label, language);
 
         if (mode) {
             newTrack.mode = mode;
         }
+        return newTrack;
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
### Description
BUG FIX: addTextTrack in VgMedia should return the new text track so it can be used.

### Checklist
Please, check that you have been followed next steps:

Y - I've read the (contributing)[https://github.com/videogular/videogular2/blob/master/CONTRIBUTING.md] guidelines
Y - Code compiles correctly (run `npm start`)
N/A - Created tests (if necessary)
Y - All tests passing (run `npm test`)
N/A - Extended the README / documentation (if necessary)
