### PR TITLE
fix(core): Add checks for the existence of window prior to attempting…

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -3,7 +3,7 @@ export * from './src/core/core';
 // CustomEvent polyfill for IE9/10/11
 (function () {
 
-    if ( typeof window['CustomEvent'] === "function" ) return false;
+    if ( typeof window === "undefined" || typeof window['CustomEvent'] === "function" ) return false;
 
     function CustomEvent ( event, params ) {
         params = params || { bubbles: false, cancelable: false, detail: undefined };


### PR DESCRIPTION
… a polyfill to prevent server crash



### Description
Running a project that includes videogular2 and server side rendering will crash with
ReferenceError: window is not defined on server start.  This is because the polyfill attempts to
apply regardless of whether or not you are attempting to render a page with a video.  This change
checks if window is undefined before attempting to access the window variable, preventing this
server crash.