### PR TITLE
Use Headless Chrome for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
-sudo: false
+sudo: required
+dist: trusty
+addons:
+  chrome: stable
 language: node_js
 cache:
   directories:
@@ -8,10 +11,8 @@ notifications:
 node_js:
   - '4'
 before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - npm i -g npm@^3.0.0
+  - sleep 1
 before_script:
   - npm prune
 script:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -70,7 +70,7 @@ module.exports = function(config) {
 
         autoWatch: true,
 
-        browsers: ['Chrome'],
+        browsers: ['ChromeHeadless'],
 
         // Karma plugins loaded
         plugins: [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,14 +1,5 @@
 module.exports = function(config) {
     var configuration = {
-
-        // Only for travis
-        customLaunchers: {
-            Chrome_travis_ci: {
-                base: 'Chrome',
-                flags: ['--no-sandbox']
-            }
-        },
-
         basePath: '.',
 
         frameworks: ['jasmine'],
@@ -99,7 +90,6 @@ module.exports = function(config) {
     };
 
     if (process.env.TRAVIS) {
-        configuration.browsers = ['Chrome_travis_ci'];
         configuration.reporters = ['spec', 'coverage'];
     }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "husky": "0.13.4",
     "jasmine-core": "2.5.2",
     "karma": "1.5.0",
-    "karma-chrome-launcher": "2.0.0",
+    "karma-chrome-launcher": "^2.1.1",
     "karma-coverage": "1.1.1",
     "karma-jasmine": "1.1.0",
     "karma-spec-reporter": "0.0.30",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
         "perf",
         "test",
         "chore",
-        "revert"
+        "revert",
+        "ci"
       ],
       "scope": {
         "required": true,


### PR DESCRIPTION
### Description

Updated karma-chrome-launcher plugin, Karma config and Travis config to use Headless Chrome to run all tests.

Advantages:

- Tests should run faster in Headless Chrome

- Run tests in Travis in Chrome stable version, instead of [outdated Chromium stuck on version 37](https://github.com/travis-ci/travis-ci/issues/3475)

- Get rid of 'black magic' in Travis configuration and less clutter in Karma configuration file

Checked:

- All tests passing (run `npm test`) :)

