### PR TITLE
fix(vg-media): Fix memory leaks when destroying playing video

### DIFF
--- a/src/core/vg-media/vg-media.ts
+++ b/src/core/vg-media/vg-media.ts
@@ -494,6 +494,17 @@ export class VgMedia implements OnInit, OnDestroy, IPlayable {
         this.timeUpdateObs.unsubscribe();
         this.volumeChangeObs.unsubscribe();
         this.errorObs.unsubscribe();
+        
+        if (this.checkBufferSubscription) {
+            this.checkBufferSubscription.unsubscribe();
+        }
+
+        if(this.syncSubscription) {
+            this.syncSubscription.unsubscribe();
+        }
+        
+        this.bufferDetected.complete();
+        this.bufferDetected.unsubscribe();
 
         this.api.unregisterMedia(this);
     }


### PR DESCRIPTION
VG-Media can hold onto subscription references when moving from page to page while a video is
playing.  Various subscriptions are set to unsubscribe on pause, but if the component is destroyed
while playing (with no pause event fired) a reference of Videogular gets held onto.  This change
adds an unsubscribe to any subscriptions that can be created (while checking for existence prior to
attempting an unsubscription).  The bufferDetected Subject also runs a complete to ensure
unsubcription of any subscribers, and then unsubcribes itself.  The unsubscription of itself might
be unnecessary, but as a Subject is both an Observable and an Observer this seemed to be the safest
approach.

565

### Description
Please explain the changes you made here. Commit your changes with `npm run commit` instead of `git commit`.

Specify if it's a fix, feature or breaking change to update the version on NPM.

Thank you!

### Checklist
Please, check that you have been followed next steps:

- I've read the (contributing)[https://github.com/videogular/videogular2/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)
