### PR TITLE
Azure Media Services manifest detection

### DIFF
--- a/src/streaming/vg-dash/vg-dash.ts
+++ b/src/streaming/vg-dash/vg-dash.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, SimpleChanges, OnChanges, OnDestroy, OnInit } from "@angular/core";
+-import { Directive, ElementRef, Input, SimpleChanges, OnChanges, OnDestroy, OnInit } from "@angular/core";
 import { VgAPI } from '../../core/services/vg-api';
 import { Subscription } from 'rxjs/Subscription';
 
@@ -48,7 +48,7 @@ export class VgDASH implements OnInit, OnChanges, OnDestroy {
         }
 
         // It's a DASH source
-        if (this.vgDash && ((this.vgDash.indexOf('.mpd') > 1) || (this.vgDash.indexOf('mpd-time-csf') > -1))) {
+        if (this.vgDash && ((this.vgDash.indexOf('.mpd') > -1) || (this.vgDash.indexOf('mpd-time-csf') > -1))) {
             this.dash = dashjs.MediaPlayer().create();
             this.dash.getDebug().setLogToBrowserConsole(false);
             this.dash.initialize(this.ref.nativeElement, this.vgDash, false);

--- a/src/streaming/vg-dash/vg-dash.ts
+++ b/src/streaming/vg-dash/vg-dash.ts
@@ -48,7 +48,7 @@ export class VgDASH implements OnInit, OnChanges, OnDestroy {
         }
 
         // It's a DASH source
-        if (this.vgDash && this.vgDash.indexOf('.mpd') > -1) {
+        if (this.vgDash && ((this.vgDash.indexOf('.mpd') > 1) || (this.vgDash.indexOf('mpd-time-csf') > -1))) {
             this.dash = dashjs.MediaPlayer().create();
             this.dash.getDebug().setLogToBrowserConsole(false);
             this.dash.initialize(this.ref.nativeElement, this.vgDash, false);

--- a/src/streaming/vg-dash/vg-dash.ts
+++ b/src/streaming/vg-dash/vg-dash.ts
@@ -1,4 +1,4 @@
--import { Directive, ElementRef, Input, SimpleChanges, OnChanges, OnDestroy, OnInit } from "@angular/core";
+import { Directive, ElementRef, Input, SimpleChanges, OnChanges, OnDestroy, OnInit } from "@angular/core";
 import { VgAPI } from '../../core/services/vg-api';
 import { Subscription } from 'rxjs/Subscription';
 

--- a/src/streaming/vg-hls/vg-hls.ts
+++ b/src/streaming/vg-hls/vg-hls.ts
@@ -52,7 +52,7 @@ export class VgHLS implements OnInit, OnChanges, OnDestroy {
 
         if (!this.preload) {
             this.subscriptions.push(
-                this.API.subscriptions.play.subscribe(
+-                this.API.subscriptions.play.subscribe(
                     () => {
                         if (this.hls) {
                             this.hls.startLoad(0);
@@ -78,7 +78,7 @@ export class VgHLS implements OnInit, OnChanges, OnDestroy {
         }
 
         // It's a HLS source
-        if (this.vgHls && ((this.vgHls.indexOf('.m3u8') > 1) || (this.vgHls.indexOf('m3u8-aapl') > -1)) && Hls.isSupported()) {
+        if (this.vgHls && ((this.vgHls.indexOf('.m3u8') > -1) || (this.vgHls.indexOf('m3u8-aapl') > -1)) && Hls.isSupported()) {
             let video:HTMLVideoElement = this.ref.nativeElement;
 
             this.hls = new Hls(this.config);

--- a/src/streaming/vg-hls/vg-hls.ts
+++ b/src/streaming/vg-hls/vg-hls.ts
@@ -78,7 +78,7 @@ export class VgHLS implements OnInit, OnChanges, OnDestroy {
         }
 
         // It's a HLS source
-        if (this.vgHls && this.vgHls.indexOf('.m3u8') > -1 && Hls.isSupported()) {
+        if (this.vgHls && ((this.vgHls.indexOf('.m3u8') > 1) || (this.vgHls.indexOf('m3u8-aapl') > -1)) && Hls.isSupported()) {
             let video:HTMLVideoElement = this.ref.nativeElement;
 
             this.hls = new Hls(this.config);

--- a/src/streaming/vg-hls/vg-hls.ts
+++ b/src/streaming/vg-hls/vg-hls.ts
@@ -52,7 +52,7 @@ export class VgHLS implements OnInit, OnChanges, OnDestroy {
 
         if (!this.preload) {
             this.subscriptions.push(
--                this.API.subscriptions.play.subscribe(
+                this.API.subscriptions.play.subscribe(
                     () => {
                         if (this.hls) {
                             this.hls.startLoad(0);


### PR DESCRIPTION
### Description
Expanded the ability of the manifest detection code to recognize Azure Media Services manifests. Azure Media Services has the option of dynamic packaging which serves a dynamic manifest (for DASH, HLS, or Smooth Streaming) that doesn't have a file extension. Added code to handle this scenario for DASH and HLS.