### PR TITLE
fix(VgFullscreenAPI): Fix null reference error when browser doesn't s…

### DIFF
--- a/src/core/services/vg-fullscreen-api.ts
+++ b/src/core/services/vg-fullscreen-api.ts
@@ -86,6 +86,13 @@ export class VgFullscreenAPI {
             this.polyfill = APIs.ios
         }
 
+        this.isAvailable = (this.polyfill != null);
+
+        if(this.polyfill == null)
+        {
+            return;
+        }
+
         let fsElemDispatcher;
 
         switch (this.polyfill.onchange) {
@@ -109,7 +116,7 @@ export class VgFullscreenAPI {
             this.onFullscreenChange();
         });
 
-        this.isAvailable = (this.polyfill != null);
+        
     }
 
     onFullscreenChange() {


### PR DESCRIPTION
…upport fullscreen api



### Description
this.available is used to show/hide the fullscreen control, but when this.polyfill is null it still
attempts to bind a listener and a switch case attempts to use this.polyfill.onchange.  This fix
moves the this.available binding above these statements and returns out of the init if fullscreen is
unavailable
