### PR TITLE
fix($package.json): yarn installing would install rxjs twice and have…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "type": "git",
     "url": "https://github.com/videogular/videogular2"
   },
-  "dependencies": {
-    "core-js": "2.4.1",
-    "reflect-metadata": "0.1.10",
-    "rxjs": "5.1.0",
-    "systemjs": "0.20.9",
-    "zone.js": "0.8.5"
+  "peerDependencies": {
+    "core-js": "^2.4.1",
+    "reflect-metadata": "^0.1.10",
+    "rxjs": "^5.1.0",
+    "systemjs": "^0.20.9",
+    "zone.js": "^0.8.5"
   },
   "devDependencies": {
     "@angular/common": "2.2.3",
@@ -25,6 +25,7 @@
     "@types/jasmine": "2.5.38",
     "codelyzer": "2.0.1",
     "commitizen": "2.9.6",
+    "core-js": "2.4.1",
     "cz-conventional-changelog": "2.0.0",
     "es6-module-loader": "0.17.11",
     "http-server": "0.10.0",
@@ -36,13 +37,17 @@
     "karma-jasmine": "1.1.0",
     "karma-spec-reporter": "0.0.30",
     "parallelshell": "2.0.0",
+    "reflect-metadata": "0.1.10",
     "remap-istanbul": "0.9.5",
     "rimraf": "2.6.1",
+    "rxjs": "5.1.0",
     "semantic-release": "6.3.2",
+    "systemjs": "0.20.9",
     "tslint": "4.5.1",
     "typescript": "2.0.10",
     "validate-commit-msg": "2.12.1",
-    "watch": "1.0.2"
+    "watch": "1.0.2",
+    "zone.js": "0.8.5"
   },
   "scripts": {
     "commitmsg": "validate-commit-msg",

--- a/src/controls/vg-playback-button/vg-playback-button.ts
+++ b/src/controls/vg-playback-button/vg-playback-button.ts
@@ -13,7 +13,7 @@ import { Subscription } from 'rxjs/Subscription';
           [attr.aria-valuetext]="ariaValue">
         {{getPlaybackRate()}}x
     </span>`,
-    styles: [ `
+    styles: [`
         vg-playback-button {
             -webkit-touch-callout: none;
             -webkit-user-select: none;
@@ -53,7 +53,7 @@ export class VgPlaybackButton implements OnInit, OnDestroy {
 
     constructor(ref: ElementRef, public API: VgAPI) {
         this.elem = ref.nativeElement;
-        this.playbackValues = [ '0.5', '1.0', '1.5', '2.0' ];
+        this.playbackValues = ['0.5', '1.0', '1.5', '2.0'];
         this.playbackIndex = 1;
     }
 
@@ -64,6 +64,7 @@ export class VgPlaybackButton implements OnInit, OnDestroy {
         else {
             this.subscriptions.push(this.API.playerReadyEvent.subscribe(() => this.onPlayerReady()));
         }
+        this.getPlaybackRate();
     }
 
     onPlayerReady() {
@@ -88,10 +89,10 @@ export class VgPlaybackButton implements OnInit, OnDestroy {
         this.playbackIndex = ++this.playbackIndex % this.playbackValues.length;
 
         if (this.target instanceof VgAPI) {
-            this.target.playbackRate = (this.playbackValues[ this.playbackIndex ]);
+            this.target.playbackRate = (this.playbackValues[this.playbackIndex]);
         }
         else {
-            this.target.playbackRate[ this.vgFor ] = (this.playbackValues[ this.playbackIndex ]);
+            this.target.playbackRate[this.vgFor] = (this.playbackValues[this.playbackIndex]);
         }
     }
 


### PR DESCRIPTION
… two versions that overlay and

takeUntil and other rxjs operators wouldn't work on custom video-controls. The errors would state
that 'takeUntil' didn't exist on Subjects. The only fix was to delete node_modules in videogular2
folder nested in the developer's project node_modules folder. This change organizes devDependencies from peerDependencies.  PeerDependencies will not install on developer's node_modules but will depend on them. It will break if they don't have them and tell them that they need them.  This shouldn't be a issue with Angular since most projects have rxjs and core.js. If they don't them will be notified that they are missing.

BREAKING CHANGE: None

[https://github.com/videogular/videogular2/issues/456](https://github.com/videogular/videogular2/issues/456)

### Description
Please explain the changes you made here. Commit your changes with `npm run commit` instead of `git commit`.

Specify if it's a fix, feature or breaking change to update the version on NPM.

Thank you!

### Checklist
Please, check that you have been followed next steps:

- I've read the (contributing)[https://github.com/videogular/videogular2/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)
