### PR TITLE
fix(controls): Set ARIA orientation in VgVolume, Set play/pause button ARIA label depends on current state.

### DIFF
--- a/src/controls/vg-play-pause/vg-play-pause.ts
+++ b/src/controls/vg-play-pause/vg-play-pause.ts
@@ -12,7 +12,7 @@ import { Subscription } from 'rxjs/Subscription';
              [class.vg-icon-play_arrow]="getState() === 'paused' || getState() === 'ended'"
              tabindex="0"
              role="button"
-             aria-label="play pause button"
+             [attr.aria-label]="getState() === 'paused'?'play':'pause'"
              [attr.aria-valuetext]="ariaValue">
         </div>`,
     styles: [ `

--- a/src/controls/vg-volume/vg-volume.ts
+++ b/src/controls/vg-volume/vg-volume.ts
@@ -19,6 +19,7 @@ import { Subscription } from 'rxjs/Subscription';
             [attr.aria-valuenow]="ariaValue"
             aria-valuemin="0"
             aria-valuemax="100"
+            aria-orientation="horizontal"
             [attr.aria-valuetext]="ariaValue + '%'"
             (click)="onClick($event)"
             (mousedown)="onMouseDown($event)">


### PR DESCRIPTION
fix(controls): Set ARIA orientation in VgVolume, Set play/pause button ARIA label depends on current state.

### Description
Here are some ARIA fixes. 
Changed play/pause button ARIA label depends on current state. It already has role='button' so screenreaders read this like 'play pause button button'.  
Added ARIA orientation state to volume slider, to let screenreader know that it's a "Left/right" slider.