### PR TITLE
fix(vgAPI): Fix syntax error in getMasterMedia and isMasterDefined

### DIFF
--- a/src/core/services/vg-api.spec.ts
+++ b/src/core/services/vg-api.spec.ts
@@ -22,10 +22,10 @@ describe('Videogular Player', () => {
         it('Should get the master media', () => {
             api.medias = {
                 main: {id: 'main'},
-                secondary: {id: 'secondary', vgMedia: true}
+                secondary: {id: 'secondary', vgMaster: true}
             };
 
-            expect(api.getMasterMedia()).toEqual({id: 'secondary', vgMedia: true});
+            expect(api.getMasterMedia()).toEqual({id: 'secondary', vgMaster: true});
         });
         it('Should get the default media when no master is defined', () => {
             api.medias = {

--- a/src/core/services/vg-api.ts
+++ b/src/core/services/vg-api.ts
@@ -32,7 +32,7 @@ export class VgAPI {
     getMasterMedia():IPlayable {
         let master:any;
         for (let id in this.medias) {
-            if (this.medias[id].vgMedia === 'true' || this.medias[id].vgMedia === true) {
+            if (this.medias[id].vgMaster === 'true' || this.medias[id].vgMaster === true) {
                 master = this.medias[id];
                 break;
             }
@@ -43,7 +43,7 @@ export class VgAPI {
     isMasterDefined():boolean {
         let result = false;
         for (let id in this.medias) {
-            if (this.medias[id].vgMedia === 'true' || this.medias[id].vgMedia === true) {
+            if (this.medias[id].vgMaster === 'true' || this.medias[id].vgMaster === true) {
                 result = true;
                 break;
             }


### PR DESCRIPTION
### Description
Within `vgAPI` `getMasterMedia` and `isMasterDefined` both were checking for `vgMedia` (an `IMediaElement`) being equal to
the boolean value `true` rather than the boolean value `vgMaster`.  This means that implementations that
include a `[vgMaster]="true"` definition always fail the test which makes `getMasterMedia` return
`getDefaultMedia`, equal to the first media object in the media collection.  This means that api
reports values in $$getAllProperties incorrectly.

This same error also existed in the vg-api unit tests, which allowed the test to erroneously pass.

This pull request resolves issue #729 
