### PR TITLE
fix(vgMedia): playPromise failures now remove the playPromise

### DIFF
--- a/src/core/vg-media/vg-media.ts
+++ b/src/core/vg-media/vg-media.ts
@@ -248,6 +248,7 @@ export class VgMedia implements OnInit, OnDestroy, IPlayable {
                     this.playPromise = null;
                 })
                 .catch(() => {
+                    this.playPromise = null;
                     // deliberately empty for the sake of eating console noise
                 });
         }


### PR DESCRIPTION
### Description
`playPromise` attempts that are rejected drop into the catch block and were not clearing the
`playPromise` reference causing all subsequent attempts to play the media to fail.  The initial
if-statement checks for the existence of a `playPromise` and returns out if it currently exists.  This
meant that autoplay videos rejected by Safari or Chrome could not be played, even by clicking the
play button.  This change nulls out of the `playPromise` reference with both successful and
unsuccessful play attempts allowing future calls to play() (for example, during a click event of the
play button) the possibility to succeed.

This pull request resolves the issue discussed in #724 

```javascript
play() {
        // short-circuit if already playing
        if (this.playPromise || (this.state !== VgStates.VG_PAUSED && this.state !== VgStates.VG_ENDED)) {
            return;
        }

        this.playPromise = this.vgMedia.play();

        // browser has async play promise
        if (this.playPromise && this.playPromise.then && this.playPromise.catch) {
            this.playPromise
                .then(() => {
                    this.playPromise = null;
                })
                .catch(() => {
                    // any time the promise ends up here the promise is never removed 
                    // and all further calls to this function will fail the if-statement above
                    // This means that the video cannot be started using vg-play-pause or vg-overlay-play
                });
        }

        return this.playPromise;
    }
```