### PR TITLE
fix(vgHLS): Trigger isLive in vg-media for live HLS manifest

### DIFF
--- a/src/streaming/vg-hls/vg-hls.ts
+++ b/src/streaming/vg-hls/vg-hls.ts
@@ -49,7 +49,15 @@ export class VgHLS implements OnInit, OnChanges, OnDestroy {
         this.crossorigin = this.ref.nativeElement.getAttribute('crossorigin');
         this.preload = this.ref.nativeElement.getAttribute('preload') !== 'none';
         this.vgFor = this.ref.nativeElement.getAttribute('vgFor');
-        this.target = this.API.getMediaById(this.vgFor);
+        
+        if(this.vgFor)
+        {
+            this.target = this.API.getMediaById(this.vgFor);
+        }
+        else{
+            this.target = this.API.getDefaultMedia();
+        }
+        
 
         this.config = <IHLSConfig>{
             autoStartLoad: this.preload
@@ -124,6 +132,13 @@ export class VgHLS implements OnInit, OnChanges, OnDestroy {
                     this.onGetBitrates.emit(videoList);
                 }
             );
+            this.hls.on(
+                Hls.Events.LEVEL_LOADED,
+                (event, data) => {
+                    this.target.isLive = data.details.live;
+                }
+            );
+
             this.hls.loadSource(this.vgHls);
             this.hls.attachMedia(video);
         }
@@ -152,5 +167,6 @@ export class VgHLS implements OnInit, OnChanges, OnDestroy {
     ngOnDestroy() {
         this.subscriptions.forEach(s => s.unsubscribe());
         this.destroyPlayer();
+        delete this.hls;
     }
 }


### PR DESCRIPTION
vg-media currently sets the isLive property by determining if total time is bound to infinity.  This
allows that option, while also tracking manifest loaded events out of hls.js that report whether a
manifest is live or not.  This should account for both standard live streams, and dvr style live events that reach an ending while someone is watching (which should change isLive to false when the X-EndList appears in the polling manifest).

This commit also deletes the hls object in an attempt to resolve the spinning wheel issue reported in issue #726.  I could not replicate the issue reliably so I don't know if this will make any substantive difference, but deleting the object is done with both the clappr and videojs hls.js implementations, so I figured why not.

#740 #741