### PR TITLE
fix(vgControls): Track playing state of media specified in vgFor

### DIFF
--- a/src/controls/vg-controls.ts
+++ b/src/controls/vg-controls.ts
@@ -73,7 +73,14 @@ export class VgControls implements OnInit, AfterViewInit, OnDestroy {
     }
 
     onPlayerReady() {
-        this.target = this.API.getMediaById(this.vgFor);
+        if(this.vgFor)
+        {
+            this.target = this.API.getMediaById(this.vgFor);
+        }
+        else
+        {
+            this.target = this.API.getDefaultMedia();
+        }
 
         this.subscriptions.push(this.target.subscriptions.play.subscribe(this.onPlay.bind(this)));
         this.subscriptions.push(this.target.subscriptions.pause.subscribe(this.onPause.bind(this)));
@@ -128,7 +135,7 @@ export class VgControls implements OnInit, AfterViewInit, OnDestroy {
     }
 
     private hideAsync() {
-        if (this.API.state === VgStates.VG_PLAYING) {
+        if (this.target.state === VgStates.VG_PLAYING) {
             this.timer = setTimeout(() => {
                 this.hideControls = true;
                 this.hidden.state(true);

--- a/src/core/vg-media/vg-media.spec.ts
+++ b/src/core/vg-media/vg-media.spec.ts
@@ -39,6 +39,7 @@ describe('Videogular Media', () => {
     });
 
     it('Should load a new media if a change on dom have been happened', () => {
+        jasmine.clock().uninstall();
         jasmine.clock().install();
 
         spyOn(elem, 'load').and.callThrough();


### PR DESCRIPTION
vgControls can set vgFor to track play/pause/ads for play and pause checking of control hiding, but
by checking this.API in the hideAsync function a project without vgMaster set can end up checking
the state of a different media than the one bound to vgControls, which could be sitting in a pause
state while the media bound to the controls is happily in a playing state.  This change sets
this.target to always have a media binding so that the controls are either controlling the one found
in vgFor or the default media of the API (meaning this adds specificity without changing the
previous result of getting state values from the default media object).

Tests have been updated to include a vgMedia object for the new binding.

#716