### PR TITLE
Fix vgFor references in docs

### DIFF
--- a/docs/modules/buffering/vg-buffering/README.md
+++ b/docs/modules/buffering/vg-buffering/README.md
@@ -12,7 +12,7 @@ Buffering component to display a buffer icon when the media is paused and loadin
 
 ```html
 <vg-player>
-    <vg-buffering [vgFor]="my-video"></vg-buffering>
+    <vg-buffering vgFor="my-video"></vg-buffering>
 
     <video #myMedia
            [vgMedia]="myMedia"

--- a/docs/modules/controls/vg-controls/README.md
+++ b/docs/modules/controls/vg-controls/README.md
@@ -14,7 +14,7 @@ Component to act as container for other components.
 
 ```html
 <vg-player>
-    <vg-controls [vgFor]="my-video" [vgAutohide]="true" [vgAutohideTime]="5">
+    <vg-controls vgFor="my-video" [vgAutohide]="true" [vgAutohideTime]="5">
         <!-- more components here -->
     </vg-controls>
 

--- a/docs/modules/controls/vg-mute/README.md
+++ b/docs/modules/controls/vg-mute/README.md
@@ -13,7 +13,7 @@ Button to toggle between current selected volume and muted volume.
 ```html
 <vg-player>
     <vg-controls>
-        <vg-mute [vgFor]="my-video"></vg-mute>
+        <vg-mute vgFor="my-video"></vg-mute>
     </vg-controls>
 
     <video #myMedia

--- a/docs/modules/controls/vg-play-pause/README.md
+++ b/docs/modules/controls/vg-play-pause/README.md
@@ -13,7 +13,7 @@ Button to toggle between play and pause states.
 ```html
 <vg-player>
     <vg-controls>
-        <vg-play-pause [vgFor]="my-video"></vg-play-pause>
+        <vg-play-pause vgFor="my-video"></vg-play-pause>
     </vg-controls>
 
     <video #myMedia

--- a/docs/modules/controls/vg-playback/README.md
+++ b/docs/modules/controls/vg-playback/README.md
@@ -14,7 +14,7 @@ Button to toggle between different playback speeds.
 ```html
 <vg-player>
     <vg-controls>
-        <vg-playback-button [vgFor]="my-video" [playbackValues]="[ '1.0', '2.0', '4.0' ]"></vg-playback-button>
+        <vg-playback-button vgFor="my-video" [playbackValues]="[ '1.0', '2.0', '4.0' ]"></vg-playback-button>
     </vg-controls>
 
     <video #myMedia

--- a/docs/modules/controls/vg-scrub-bar/README.md
+++ b/docs/modules/controls/vg-scrub-bar/README.md
@@ -16,7 +16,7 @@ This component also has listeners to seek when user clicks or drag in the scrub 
 ```html
 <vg-player>
     <vg-controls>
-        <vg-scrub-bar [vgFor]="my-video" [vgSlider]="false">
+        <vg-scrub-bar vgFor="my-video" [vgSlider]="false">
             <!-- more components here -->
         </vg-scrub-bar>
     </vg-controls>

--- a/docs/modules/controls/vg-scrub-bar/vg-scrub-bar-buffering-time/README.md
+++ b/docs/modules/controls/vg-scrub-bar/vg-scrub-bar-buffering-time/README.md
@@ -14,7 +14,7 @@ Component to display the current buffering percentage loaded.
 <vg-player>
     <vg-controls>
         <vg-scrub-bar>
-            <vg-scrub-bar-buffering-time [vgFor]="my-video"></vg-scrub-bar-buffering-time>
+            <vg-scrub-bar-buffering-time vgFor="my-video"></vg-scrub-bar-buffering-time>
         </vg-scrub-bar>
     </vg-controls>
 

--- a/docs/modules/controls/vg-scrub-bar/vg-scrub-bar-cue-points/README.md
+++ b/docs/modules/controls/vg-scrub-bar/vg-scrub-bar-cue-points/README.md
@@ -15,7 +15,7 @@ Component to display in a bar all cue points in a `TextTrackCueList`.
 <vg-player>
     <vg-controls>
         <vg-scrub-bar>
-            <vg-scrub-bar-cue-points [vgFor]="my-video" [vgCuePoints]="metadataTrack.cues"></vg-scrub-bar-cue-points>
+            <vg-scrub-bar-cue-points vgFor="my-video" [vgCuePoints]="metadataTrack.cues"></vg-scrub-bar-cue-points>
         </vg-scrub-bar>
     </vg-controls>
 

--- a/docs/modules/controls/vg-scrub-bar/vg-scrub-bar-current-time/README.md
+++ b/docs/modules/controls/vg-scrub-bar/vg-scrub-bar-current-time/README.md
@@ -15,7 +15,7 @@ Component to display the current time in percentage as an horizontal bar.
 <vg-player>
     <vg-controls>
         <vg-scrub-bar>
-            <vg-scrub-bar-current-time [vgFor]="my-video" [vgSlider]="true"></vg-scrub-bar-current-time>
+            <vg-scrub-bar-current-time vgFor="my-video" [vgSlider]="true"></vg-scrub-bar-current-time>
         </vg-scrub-bar>
     </vg-controls>
 

--- a/docs/modules/controls/vg-time-display/README.md
+++ b/docs/modules/controls/vg-time-display/README.md
@@ -15,9 +15,9 @@ Component to display the current time, total time or time left for the current m
 ```html
 <vg-player>
     <vg-controls>
-        <vg-time-display [vgFor]="my-video" [vgProperty]="'current'" [vgFormat]="'mm:ss'"></vg-time-display>
-        <vg-time-display [vgFor]="my-video" [vgProperty]="'left'" [vgFormat]="'mm:ss'"></vg-time-display>
-        <vg-time-display [vgFor]="my-video" [vgProperty]="'total'" [vgFormat]="'mm:ss'"></vg-time-display>
+        <vg-time-display vgFor="my-video" [vgProperty]="'current'" [vgFormat]="'mm:ss'"></vg-time-display>
+        <vg-time-display vgFor="my-video" [vgProperty]="'left'" [vgFormat]="'mm:ss'"></vg-time-display>
+        <vg-time-display vgFor="my-video" [vgProperty]="'total'" [vgFormat]="'mm:ss'"></vg-time-display>
     </vg-controls>
 
     <video #myMedia

--- a/docs/modules/controls/vg-track-selector/README.md
+++ b/docs/modules/controls/vg-track-selector/README.md
@@ -13,7 +13,7 @@ Component to display a selector for tracks of kind `subtitles` registered to the
 ```html
 <vg-player>
     <vg-controls>
-        <vg-track-selector [vgFor]="my-video"></vg-track-selector>
+        <vg-track-selector vgFor="my-video"></vg-track-selector>
     </vg-controls>
 
     <video #myMedia

--- a/docs/modules/controls/vg-volume/README.md
+++ b/docs/modules/controls/vg-volume/README.md
@@ -13,7 +13,7 @@ Component to display an horizontal slider bar to change the volume of the curren
 ```html
 <vg-player>
     <vg-controls>
-        <vg-volume [vgFor]="my-video"></vg-volume>
+        <vg-volume vgFor="my-video"></vg-volume>
     </vg-controls>
 
     <video #myMedia

--- a/docs/modules/overlay-play/vg-overlay-play/README.md
+++ b/docs/modules/overlay-play/vg-overlay-play/README.md
@@ -12,7 +12,7 @@ Component to display a big play button over the video.
 
 ```html
 <vg-player>
-    <vg-overlay-play [vgFor]="my-video"></vg-overlay-play>
+    <vg-overlay-play vgFor="my-video"></vg-overlay-play>
 
     <video #myMedia
            [vgMedia]="myMedia"


### PR DESCRIPTION
vgFor is expecting an id string, not an object. Although, it would be
cool if [vgFor]="myMedia" also worked.

### Description
Please explain the changes you made here. Commit your changes with `npm run commit` instead of `git commit`.

Specify if it's a fix, feature or breaking change to update the version on NPM.

Thank you!

### Checklist
Please, check that you have been followed next steps:

- I've read the (contributing)[https://github.com/videogular/videogular2/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)
