### PR TITLE
fix(tests): Update tests for last versions of chrome, minor update to husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cz-conventional-changelog": "2.0.0",
     "es-module-loader": "2.2.8",
     "http-server": "0.10.0",
-    "husky": "0.13.4",
+    "husky": "1.3.0",
     "jasmine-core": "2.5.2",
     "karma": "1.5.0",
     "karma-chrome-launcher": "^2.1.1",
@@ -54,7 +54,6 @@
     "build:travis": "ngc",
     "postbuild:travis": "npm run test",
     "clean": "rimraf -rf ./src/**/*.js && rimraf -rf ./src/**/*.d.ts && rimraf -rf ./compiled",
-    "precommit": "npm test",
     "commit": "git-cz",
     "coverage": "http-server -c-1 -o -s -p 9875 ./coverage",
     "start": "parallelshell \"npm run watch:ts\" \"npm run start:coverage-server\"",
@@ -66,6 +65,11 @@
     "watch:ts": "watch \"npm run build\" src",
     "parallelshell": "parallelshell",
     "lint": "tslint '**/*.ts' -e 'node_modules/**/*' -e 'compiled/**/**'  --fix --noUnusedParameters --noUnusedLocals"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test"
+    }
   },
   "engines": {
     "node": ">= 4"

--- a/src/core/services/vg-fullscreen-api.spec.ts
+++ b/src/core/services/vg-fullscreen-api.spec.ts
@@ -1,6 +1,5 @@
 import {QueryList} from "@angular/core";
 import {VgFullscreenAPI} from "./vg-fullscreen-api";
-import {VgMedia} from "../vg-media/vg-media";
 import {VgUtils} from "./vg-utils";
 
 describe('Videogular Player', () => {
@@ -19,12 +18,12 @@ describe('Videogular Player', () => {
     });
 
     it('Should create polyfills on init', () => {
-        expect(fsAPI.polyfill.enabled).toBe('webkitFullscreenEnabled');
-        expect(fsAPI.polyfill.element).toBe('webkitFullscreenElement');
-        expect(fsAPI.polyfill.request).toBe('webkitRequestFullscreen');
-        expect(fsAPI.polyfill.exit).toBe('webkitExitFullscreen');
-        expect(fsAPI.polyfill.onchange).toBe('webkitfullscreenchange');
-        expect(fsAPI.polyfill.onerror).toBe('webkitfullscreenerror');
+        expect(fsAPI.polyfill.enabled).toBe('fullscreenEnabled');
+        expect(fsAPI.polyfill.element).toBe('fullscreenElement');
+        expect(fsAPI.polyfill.request).toBe('requestFullscreen');
+        expect(fsAPI.polyfill.exit).toBe('exitFullscreen');
+        expect(fsAPI.polyfill.onchange).toBe('fullscreenchange');
+        expect(fsAPI.polyfill.onerror).toBe('fullscreenerror');
     });
 
     it('Should request an element to enter in fullscreen mode (desktop)', () => {
@@ -68,11 +67,11 @@ describe('Videogular Player', () => {
     });
 
     it('Should enter in fullscreen mode', () => {
-        spyOn(<any>elem, 'webkitRequestFullscreen').and.callThrough();
+        spyOn(<any>elem, 'requestFullscreen').and.callThrough();
 
         fsAPI.enterElementInFullScreen(elem);
 
-        expect((<any>elem).webkitRequestFullscreen).toHaveBeenCalled();
+        expect((<any>elem).requestFullscreen).toHaveBeenCalled();
     });
 
     it('Should request an element to exit from fullscreen mode (native)', () => {


### PR DESCRIPTION
Fix tests for last version of chrome

- Update husky pre-commit hook location in **package.json** as suggested by the authors of this package: [husky repository](https://github.com/typicode/husky)

- Update the tests in **vg-fullscreen-api.spec.ts** to allow successful tests on last version of chrome.

- Update version of **husky** to allow pushing with a node version that use nvm.

BREAKING CHANGE: None that I am aware of;

### Checklist
- I've read the (contributing)[https://github.com/videogular/videogular2/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)
