### PR TITLE
test(chrome) Fix chrome tests for last versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cz-conventional-changelog": "2.0.0",
     "es-module-loader": "2.2.8",
     "http-server": "0.10.0",
-    "husky": "0.13.4",
+    "husky": "^1.3.0",
     "jasmine-core": "2.5.2",
     "karma": "1.5.0",
     "karma-chrome-launcher": "^2.1.1",

--- a/src/core/services/vg-fullscreen-api.spec.ts
+++ b/src/core/services/vg-fullscreen-api.spec.ts
@@ -19,12 +19,12 @@ describe('Videogular Player', () => {
     });
 
     it('Should create polyfills on init', () => {
-        expect(fsAPI.polyfill.enabled).toBe('webkitFullscreenEnabled');
-        expect(fsAPI.polyfill.element).toBe('webkitFullscreenElement');
-        expect(fsAPI.polyfill.request).toBe('webkitRequestFullscreen');
-        expect(fsAPI.polyfill.exit).toBe('webkitExitFullscreen');
-        expect(fsAPI.polyfill.onchange).toBe('webkitfullscreenchange');
-        expect(fsAPI.polyfill.onerror).toBe('webkitfullscreenerror');
+        expect(fsAPI.polyfill.enabled).toBe('fullscreenEnabled');
+        expect(fsAPI.polyfill.element).toBe('fullscreenElement');
+        expect(fsAPI.polyfill.request).toBe('requestFullscreen');
+        expect(fsAPI.polyfill.exit).toBe('exitFullscreen');
+        expect(fsAPI.polyfill.onchange).toBe('fullscreenchange');
+        expect(fsAPI.polyfill.onerror).toBe('fullscreenerror');
     });
 
     it('Should request an element to enter in fullscreen mode (desktop)', () => {
@@ -68,11 +68,11 @@ describe('Videogular Player', () => {
     });
 
     it('Should enter in fullscreen mode', () => {
-        spyOn(<any>elem, 'webkitRequestFullscreen').and.callThrough();
+        spyOn(<any>elem, 'requestFullscreen').and.callThrough();
 
         fsAPI.enterElementInFullScreen(elem);
 
-        expect((<any>elem).webkitRequestFullscreen).toHaveBeenCalled();
+        expect((<any>elem).requestFullscreen).toHaveBeenCalled();
     });
 
     it('Should request an element to exit from fullscreen mode (native)', () => {


### PR DESCRIPTION
### Description
Update method names of some tests in /vg-api.spec.ts to allow compatibility with last versions of chrome in tests.
Update version of husky.

### Checklist
- I've read the (contributing)[https://github.com/videogular/videogular2/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)
