### PR TITLE
Add missing method to Google IMA definition

### DIFF
--- a/src/ima-ads/google.ima.ts
+++ b/src/ima-ads/google.ima.ts
@@ -7,6 +7,7 @@ declare namespace google {
         export class AdDisplayContainer {
             constructor(containerElement:HTMLElement);
             initialize():void;
+            destroy():void;
         }
 
         /**


### PR DESCRIPTION
### Description
Added a missing method to the definition of the Google IMA AdContainer class that allows the user to destroy any DOM elements created by the IMA.

[Documentation for the method can be found here](https://developers.google.com/interactive-media-ads/docs/sdks/html5/v3/reference/js/ima.AdDisplayContainer#destroy)

### Checklist
Please, check that you have been followed next steps:

✓ I've read the (contributing)[https://github.com/videogular/videogular2/blob/master/CONTRIBUTING.md] guidelines
✓ Code compiles correctly (run `npm start`)
✓ Created tests (if necessary)
✓ All tests passing (run `npm test`)
N/A - Extended the README / documentation (if necessary)
