### PR TITLE
scrub-bar - fix aria-valuetext/aria-valuenow attributes

### DIFF
--- a/src/controls/vg-scrub-bar/vg-scrub-bar-current-time/vg-scrub-bar-current-time.spec.ts
+++ b/src/controls/vg-scrub-bar/vg-scrub-bar-current-time/vg-scrub-bar-current-time.spec.ts
@@ -56,5 +56,18 @@ describe('Scrub bar current time', () => {
 
             expect(percent).toEqual('25%');
         });
+
+        it('should return 27% when current time is 3 and total time is 11', () => {
+            scrubBarCurrentTime.target = {
+                time: {
+                    current: 3,
+                    total: 11
+                }
+            };
+
+            let percent = scrubBarCurrentTime.getPercentage();
+
+            expect(percent).toEqual('27%');
+        });
     });
 });

--- a/src/controls/vg-scrub-bar/vg-scrub-bar.ts
+++ b/src/controls/vg-scrub-bar/vg-scrub-bar.ts
@@ -19,7 +19,7 @@ import { Subscription } from 'rxjs';
              [attr.aria-valuenow]="getPercentage()"
              aria-valuemin="0"
              aria-valuemax="100"
-             [attr.aria-valuetext]="getPercentage() + '%'">
+             [attr.aria-valuetext]="getPercentage()">
             <ng-content></ng-content>
         </div>
 
@@ -246,7 +246,7 @@ export class VgScrubBar implements OnInit, OnDestroy {
     }
 
     getPercentage() {
-        return this.target ? ((this.target.time.current * 100) / this.target.time.total) + '%' : '0%';
+        return this.target ? Math.round((this.target.time.current * 100) / this.target.time.total) + '%' : '0%';
     }
 
     onHideScrubBar(hide: boolean) {


### PR DESCRIPTION
### Description
1. For now `aria-valuetext`/`aria-valuenow` has not rounded values which is undesirable - readers reads whole text (eg. "46.55433453543%").
2. `aria-valuetext` has % decorator (getPercentage already return string with % at the end).
