### PR TITLE
fix: 🐛 Fix issue #810, seekbar doesn't go crazy when cursor out

### DIFF
--- a/src/controls/vg-scrub-bar/vg-scrub-bar.ts
+++ b/src/controls/vg-scrub-bar/vg-scrub-bar.ts
@@ -178,7 +178,8 @@ export class VgScrubBar implements OnInit, OnDestroy {
     onMouseMoveScrubBar($event: any) {
         if (this.target) {
             if (!this.target.isLive && this.vgSlider && this.isSeeking) {
-                this.seekMove($event.offsetX);
+                const dif = (((window.innerWidth - this.elem.offsetWidth)/2)).toFixed(0);
+                this.seekMove(Number($event.clientX) - Number(dif));
             }
         }
     }
@@ -187,7 +188,8 @@ export class VgScrubBar implements OnInit, OnDestroy {
     onMouseUpScrubBar($event: any) {
         if (this.target) {
             if (!this.target.isLive && this.vgSlider && this.isSeeking) {
-                this.seekEnd($event.offsetX);
+                const dif = (((window.innerWidth - this.elem.offsetWidth)/2)).toFixed(0);
+                this.seekEnd(Number($event.clientX) - Number(dif));
             }
         }
     }


### PR DESCRIPTION
Fix issue #810, seekbar doesn't go crazy when cursor is sliding the
seekbar and gets out of the player. Instead getting offsetX, now get the
cursor x coordinate and calculates its position relative to the
scrub-bar to calculate the correct position.

BREAKING CHANGE: 🧨 none

✅ Closes: #810

### Description
Please explain the changes you made here. Commit your changes with `npm run commit` instead of `git commit`.

Specify if it's a fix, feature or breaking change to update the version on NPM.

Thank you!

### Checklist
Please, check that you have been followed next steps:

- I've read the (contributing)[https://github.com/videogular/videogular2/blob/master/CONTRIBUTING.md] guidelines
- Code compiles correctly (run `npm start`)
- Created tests (if necessary)
- All tests passing (run `npm test`)
- Extended the README / documentation (if necessary)
